### PR TITLE
fix can't serialize TypeIndex in iOS li2cpp

### DIFF
--- a/ValueVariant.Generator/ValueVariantTemplate.tt
+++ b/ValueVariant.Generator/ValueVariantTemplate.tt
@@ -167,7 +167,7 @@ namespace <#= Namespace #>
         {
             public void Serialize(ref MessagePackWriter writer, T value, MessagePackSerializerOptions options)
             {
-                options.Resolver.GetFormatterWithVerify<TypeIndex>().Serialize(ref writer, value.Index, options);
+                options.Resolver.GetFormatterWithVerify<byte>().Serialize(ref writer, (byte)value.Index, options);
                 switch (value.Index) {
                     case TypeIndex.None: return;
 <#   for (var i = 1; i <= Count; ++i) { #>
@@ -179,7 +179,7 @@ namespace <#= Namespace #>
 
             public T Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
             {
-                var index = options.Resolver.GetFormatterWithVerify<TypeIndex>().Deserialize(ref reader, options);
+                var index = (TypeIndex)options.Resolver.GetFormatterWithVerify<byte>().Deserialize(ref reader, options);
                 switch (index) {
                     case TypeIndex.None: return default(T);
 <#   for (var i = 1; i <= Count; ++i) { #>

--- a/ValueVariant.Generator/ValueVariantTemplate.tt
+++ b/ValueVariant.Generator/ValueVariantTemplate.tt
@@ -53,6 +53,9 @@ namespace <#= Namespace #>
 <# } #>
         }
 
+<# if (Options.HasFlag(ValueVariantGenerateOptions.MessagePackFormatter)) { #>
+        [MessagePackFormatter(typeof(<#= TypeName #>.TypeIndexFormatter))]
+<# } #>
         public enum TypeIndex : byte { None, <#= Join(1, Count, e => $"Type{e}") #> }
 
         private readonly Union Value;
@@ -187,6 +190,19 @@ namespace <#= Namespace #>
 <#   } #>
                     default: throw new InvalidOperationException();
                 }
+            }
+        }
+
+        private sealed class TypeIndexFormatter : IMessagePackFormatter<TypeIndex>
+        {
+            public void Serialize(ref MessagePackWriter writer, TypeIndex value, MessagePackSerializerOptions options)
+            {
+                writer.Write((Int32)value);
+            }
+
+            public TypeIndex Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+            {
+                return (TypeIndex)reader.ReadInt32();
             }
         }
 <# } #>

--- a/ValueVariant.Generator/ValueVariantTemplate.tt
+++ b/ValueVariant.Generator/ValueVariantTemplate.tt
@@ -53,9 +53,6 @@ namespace <#= Namespace #>
 <# } #>
         }
 
-<# if (Options.HasFlag(ValueVariantGenerateOptions.MessagePackFormatter)) { #>
-        [MessagePackFormatter(typeof(<#= TypeName #>.TypeIndexFormatter))]
-<# } #>
         public enum TypeIndex : byte { None, <#= Join(1, Count, e => $"Type{e}") #> }
 
         private readonly Union Value;
@@ -190,19 +187,6 @@ namespace <#= Namespace #>
 <#   } #>
                     default: throw new InvalidOperationException();
                 }
-            }
-        }
-
-        private sealed class TypeIndexFormatter : IMessagePackFormatter<TypeIndex>
-        {
-            public void Serialize(ref MessagePackWriter writer, TypeIndex value, MessagePackSerializerOptions options)
-            {
-                writer.Write((Int32)value);
-            }
-
-            public TypeIndex Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
-            {
-                return (TypeIndex)reader.ReadInt32();
             }
         }
 <# } #>


### PR DESCRIPTION
## 概要

iOSで `ValueVariant` を使って定義した変数をSerializeしようとすると `TypeIndex Formatter Not Found` エラーになる

## 対応

~TypeIndexFormatter を追加~
Serialize/Deserialize 時にcastするようにした